### PR TITLE
Fix build

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/HEAD/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,8 @@ dependencyResolutionManagement {
 
 develocity {
     buildScan {
+        // required until we can upgrade to Gradle 8.8
+        val buildParameters = the<BuildParametersExtension>()
         if (buildParameters.ci) {
             termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
             termsOfUseAgree = "yes"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,12 +15,13 @@ dependencyResolutionManagement {
     repositories.mavenCentral()
 }
 
-if (the<BuildParametersExtension>().ci) {
-    gradleEnterprise {
-        buildScan {
-            publishAlways()
-            termsOfServiceUrl = "https://gradle.com/terms-of-service"
-            termsOfServiceAgree = "yes"
+develocity {
+    buildScan {
+        if (buildParameters.ci) {
+            termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+            termsOfUseAgree = "yes"
+        } else {
+            publishing.onlyIf { false }
         }
     }
 }


### PR DESCRIPTION
Rolls back the upgrade to Gradle 8.8-rc-1 which seems to have broken the samples test. Also rolls back a rollback of updating the develocity plugin configuration, because we suspected that to be the culprit.
