### PR TITLE
Remove 'org.apache.tomcat:tomcat-websocket' from JAVAX_WEBSOCKET_API_RULE

### DIFF
--- a/src/main/java/org/gradlex/jvm/dependency/conflict/detection/rules/CapabilityDefinition.java
+++ b/src/main/java/org/gradlex/jvm/dependency/conflict/detection/rules/CapabilityDefinition.java
@@ -431,7 +431,6 @@ public enum CapabilityDefinition {
             "javax.websocket:javax.websocket-client-api", // in javax namespace, websocket-api and websocket-client-api overlap
             "jakarta.websocket:jakarta.websocket-client-api",
             "org.apache.tomcat:tomcat-websocket-api",
-            "org.apache.tomcat:tomcat-websocket",
             "org.apache.tomcat.embed:tomcat-embed-websocket",
             "org.eclipse.jetty.toolchain:jetty-javax-websocket-api"
     ),


### PR DESCRIPTION
Jar does not contain the `javax` API.