### PR TITLE
Split JAVAX_MAIL_PROVIDER out of JAVAX_MAIL_API

### DIFF
--- a/samples/sample-all/build.out
+++ b/samples/sample-all/build.out
@@ -154,11 +154,12 @@ compileClasspath - Compile classpath for source set 'main'.
 |    \--- org.slf4j:slf4j-api:1.6.1 -> 2.0.12 (*)
 +--- org.apache.commons:commons-io:1.3.2 -> commons-io:commons-io:2.11.0
 +--- org.apache.geronimo.javamail:geronimo-javamail_1.3.1_mail:1.1 -> com.sun.mail:javax.mail:1.6.2 (*)
-+--- org.apache.geronimo.javamail:geronimo-javamail_1.3.1_provider:1.1 -> com.sun.mail:javax.mail:1.6.2 (*)
++--- org.apache.geronimo.javamail:geronimo-javamail_1.3.1_provider:1.1 -> org.apache.geronimo.javamail:geronimo-javamail_1.6_provider:1.0.1
+|    \--- org.apache.geronimo.specs:geronimo-javamail_1.6_spec:1.0.1 -> com.sun.mail:javax.mail:1.6.2 (*)
 +--- org.apache.geronimo.javamail:geronimo-javamail_1.4_mail:1.8.4 -> com.sun.mail:javax.mail:1.6.2 (*)
-+--- org.apache.geronimo.javamail:geronimo-javamail_1.4_provider:1.8.3 -> com.sun.mail:javax.mail:1.6.2 (*)
++--- org.apache.geronimo.javamail:geronimo-javamail_1.4_provider:1.8.3 -> org.apache.geronimo.javamail:geronimo-javamail_1.6_provider:1.0.1 (*)
 +--- org.apache.geronimo.javamail:geronimo-javamail_1.6_mail:1.0.1 -> com.sun.mail:javax.mail:1.6.2 (*)
-+--- org.apache.geronimo.javamail:geronimo-javamail_1.6_provider:1.0.1 -> com.sun.mail:javax.mail:1.6.2 (*)
++--- org.apache.geronimo.javamail:geronimo-javamail_1.6_provider:1.0.1 (*)
 +--- org.apache.geronimo.specs:geronimo-javamail_1.3.1_spec:1.3 -> com.sun.mail:javax.mail:1.6.2 (*)
 +--- org.apache.geronimo.specs:geronimo-javamail_1.4_spec:1.6 -> com.sun.mail:javax.mail:1.6.2 (*)
 +--- org.apache.geronimo.specs:geronimo-javamail_1.6_spec:1.0.1 -> com.sun.mail:javax.mail:1.6.2 (*)

--- a/src/main/java/org/gradlex/jvm/dependency/conflict/detection/rules/CapabilityDefinition.java
+++ b/src/main/java/org/gradlex/jvm/dependency/conflict/detection/rules/CapabilityDefinition.java
@@ -372,14 +372,16 @@ public enum CapabilityDefinition {
             "com.sun.mail:javax.mail", // API + Implementation
             "com.sun.mail:jakarta.mail", // API + Implementation
             "org.apache.geronimo.javamail:geronimo-javamail_1.3.1_mail",
-            "org.apache.geronimo.javamail:geronimo-javamail_1.3.1_provider",
             "org.apache.geronimo.specs:geronimo-javamail_1.3.1_spec",
             "org.apache.geronimo.javamail:geronimo-javamail_1.4_mail",
-            "org.apache.geronimo.javamail:geronimo-javamail_1.4_provider",
             "org.apache.geronimo.specs:geronimo-javamail_1.4_spec",
             "org.apache.geronimo.javamail:geronimo-javamail_1.6_mail",
-            "org.apache.geronimo.javamail:geronimo-javamail_1.6_provider",
             "org.apache.geronimo.specs:geronimo-javamail_1.6_spec"
+    ),
+    JAVAX_MAIL_PROVIDER(HIGHEST_VERSION, JavaxMailApiRule.class,
+            "org.apache.geronimo.javamail:geronimo-javamail_1.3.1_provider",
+            "org.apache.geronimo.javamail:geronimo-javamail_1.4_provider",
+            "org.apache.geronimo.javamail:geronimo-javamail_1.6_provider"
     ),
     JAVAX_PERSISTENCE_API(HIGHEST_VERSION, JavaxPersistenceApiRule.class,
             "javax.persistence:javax.persistence-api",


### PR DESCRIPTION
The 'geronimo-javamail' modules do not contain the API.