### PR TITLE
Deprecate GuaveComponentRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 2.4
 * [Fix] [#238](https://github.com/gradlex-org/jvm-dependency-conflict-resolution/issues/238) Patch DSL now works for dependencies with non-standard variant names (e.g. com.google.guava).
+* [Deprecation] [#251](https://github.com/gradlex-org/jvm-dependency-conflict-resolution/issues/251) Deprecate GuavaComponentRule in favor of more general patch DSL.
 
 ## Version 2.3
 * [New Rule] [#66](https://github.com/gradlex-org/jvm-dependency-conflict-resolution/issues/66) itext:itext / com.lowagie:itext (Thanks [Björn Kautler](https://github.com/Vampire) for reporting)

--- a/README.md
+++ b/README.md
@@ -100,18 +100,11 @@ If some of the transitive dependencies are not wanted in your case, you can fine
 jvmDependencyConflicts {
     patch {
         module("com.google.guava:guava") {
-            removeDependency("com.google.code.findbugs:jsr305")
             reduceToCompileOnlyApiDependency("com.google.errorprone:error_prone_annotations")
+            reduceToCompileOnlyApiDependency("com.google.j2objc:j2objc-annotations")
+            reduceToCompileOnlyApiDependency("org.jspecify:jspecify")
         }
     }
-}
-```
-
-If you need the previous behavior for older Guava versions, you can explicitly apply the `GuavaComponentRule`.
-
-```kotlin
-dependencies.components {
-    withModule<GuavaComponentRule>("com.google.guava:guava")
 }
 ```
 

--- a/src/main/java/org/gradlex/jvm/dependency/conflict/resolution/rules/GuavaComponentRule.java
+++ b/src/main/java/org/gradlex/jvm/dependency/conflict/resolution/rules/GuavaComponentRule.java
@@ -29,8 +29,24 @@ import java.util.List;
 /**
  * Kept for individual usage to get the patch functionality for older Guava versions.
  * Might be removed in future versions.
+ *
+ * @deprecated use patch DSL:
+ * <p>
+ *     <pre>
+ *         jvmDependencyConflicts {
+ *           patch {
+ *             module("com.google.guava:guava") {
+ *               reduceToCompileOnlyApiDependency("com.google.errorprone:error_prone_annotations")
+ *               reduceToCompileOnlyApiDependency("com.google.j2objc:j2objc-annotations")
+ *               reduceToCompileOnlyApiDependency("org.jspecify:jspecify")
+ *             }
+ *           }
+ *         }
+ *     </pre>
+ * </p>
  */
 @CacheableRule
+@Deprecated
 abstract public class GuavaComponentRule implements ComponentMetadataRule {
 
     private final static Attribute<String> TARGET_JVM_ENVIRONMENT_ATTRIBUTE =

--- a/src/test/groovy/org/gradlex/jvm/dependency/conflict/test/GuavaClasspathTest.groovy
+++ b/src/test/groovy/org/gradlex/jvm/dependency/conflict/test/GuavaClasspathTest.groovy
@@ -121,12 +121,8 @@ class GuavaClasspathTest extends Specification {
                 result.add([it[0], it[1], it[2], 'standard-jvm', 'runtimeClasspath'])
             }
         }
-        if (System.getProperty("gradleVersionUnderTest") == "7.6.4") {
-            // only do all permutations for one Gradle version
-            return result
-        }
-        // reduced amount of permutations
-        return result.subList(0, 80)
+        // The rule we are testing is Deprecated, until we remove it just test one permutation
+        return result.subList(0, 4)
     }
 
     @Unroll


### PR DESCRIPTION
It does no longer fit the current Guava release, which replaced jsr305 with jspecify. Users can use the patch DSL if needed. The rule will be removed in the next major release.

Resolves #251